### PR TITLE
Update package.json to keep level-party up-to-date

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bitcoinjs-lib": "^1.2.0",
     "helloblock-js": "^0.2.5",
     "ip": "^0.3.2",
-    "level-party": "^1.0.1",
+    "level-party": "^3.0.4",
     "native-dns": "^0.7.0",
     "raw-op-return": "git+https://github.com/quartzjer/raw-op-return.git",
     "yargs": "^1.3.3"


### PR DESCRIPTION
Keep `level-party` up-to-dated. The old version cause a problem when issuing `yarn install`:

```text
λ bigsonata blockname → λ git master* → yarn install
yarn install v0.18.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
[1/1] ⠐ leveldown: build error
[-/1] ⠐ waiting...
[-/1] ⠐ waiting...
[-/1] ⠐ waiting...
error /media/Data/@Work/IdeaProjects/play/blockname/node_modules/leveldown: Command failed.
Exit code: 1
Command: sh
Arguments: -c node-gyp rebuild
Directory: /media/Data/@Work/IdeaProjects/play/blockname/node_modules/leveldown
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@3.4.0
gyp info using node@6.9.1 | linux | x64
gyp http GET https://nodejs.org/download/release/v6.9.1/node-v6.9.1-headers.tar.gz
gyp http 200 https://nodejs.org/download/release/v6.9.1/node-v6.9.1-headers.tar.gz
gyp http GET https://nodejs.org/download/release/v6.9.1/SHASUMS256.txt
gyp http 200 https://nodejs.org/download/release/v6.9.1/SHASUMS256.txt
...
```

Using the latest version of `level-party` resolves the problem above